### PR TITLE
Add healthcheck for production deploy

### DIFF
--- a/launch/cron-admin.yml
+++ b/launch/cron-admin.yml
@@ -16,5 +16,5 @@ expose:
   proto: http
   health_check:
     type: http
-    path: /ping
+    path: /healthcheck
 dependencies: []

--- a/server/server.go
+++ b/server/server.go
@@ -58,6 +58,11 @@ func jsonHandler(handler func(*http.Request) (interface{}, int, error)) func(htt
 }
 
 func setupHandlers(r *mux.Router, database db.DB) {
+	r.HandleFunc("/healthcheck", jsonHandler(func(req *http.Request) (interface{}, int, error) {
+		defer req.Body.Close()
+		return nil, 200, nil
+	})).Methods("GET")
+
 	r.HandleFunc("/active-functions", jsonHandler(func(req *http.Request) (interface{}, int, error) {
 		defer req.Body.Close()
 		activeJobs, getErr := database.GetDistinctActiveFunctions()


### PR DESCRIPTION
To attach to a prod instance we need a valid health check route. 
