### PR TITLE
Fix JobDetails page when no jobs are found

### DIFF
--- a/static/js/components/JobDetails.jsx
+++ b/static/js/components/JobDetails.jsx
@@ -196,10 +196,10 @@ var JobDetails = React.createClass({
   },
 
   render: function() {
-    var active_jobs = this.state.jobs.filter(function (val) {
+    var active_jobs = (this.state.jobs || []).filter(function (val) {
         return val.IsActive;
     });
-    var inactive_jobs = this.state.jobs.filter(function (val) {
+    var inactive_jobs = (this.state.jobs || []).filter(function (val) {
         return !val.IsActive;
     });
 


### PR DESCRIPTION
In particular we fix a problem when JobDetails was trying to filter "null"
