### PR TITLE
New features: JSON workload parsing and created time

### DIFF
--- a/static/js/components/JobDetails.jsx
+++ b/static/js/components/JobDetails.jsx
@@ -21,7 +21,7 @@ var AddForm = React.createClass({
   formSubmit: function(e) {
     e.preventDefault();
     var crontime = this.refs.crontime.getInputDOMNode().value;
-    var workload = this.refs.workload.getInputDOMNode().value;
+    var workload = this.refs.workload.getInputDOMNode().value.trim();
 
     if (!this.state.json_workload_checked && this.raiseJSONWorkloadWarning(workload)) {
       this.setState({json_workload_checked:true});

--- a/static/js/components/JobDetails.jsx
+++ b/static/js/components/JobDetails.jsx
@@ -39,7 +39,7 @@ var AddForm = React.createClass({
     }
 
     var crontime_placeholder = 'Cron time: (e.g.  0 13 */4 * * 1-5)';
-    var workload_placeholder = 'Workload: (e.g. "--task=job" or {"task":"job"})';
+    var workload_placeholder = 'Workload: (e.g. --task=job or {"task":"job"})';
     return (
       <div>
         {this.cronAlert()}
@@ -190,8 +190,9 @@ var JobDetails = React.createClass({
   },
 
   cronUsage: function() {
+    var msg = "Note: To reduce errors, direct modifications aren't currently supported. Please instead deactivate the old job and add a new.";
     return (
-      <Alert bsStyle="info">For more information on cron convention please see <a href="https://github.com/ncb000gt/node-cron"> the README to the node package clever-cron uses.</a></Alert>
+      <Alert bsStyle="info">{msg}</Alert>
     );
   },
 

--- a/static/js/components/JobDetails.jsx
+++ b/static/js/components/JobDetails.jsx
@@ -132,6 +132,12 @@ var CronRow = React.createClass({
     });
   },
 
+  formatTime: function(created) {
+    input_format = "YYYY-MM-DDTHH:mm:SSSSZ";
+    output_format = "YYYY-MM-DD";
+    return moment(created, input_format).format(output_format);
+  },
+
   render: function() {
     var job = this.props.job;
     var display = this.props.job.IsActive ? "Deactivate":"Activate";
@@ -143,6 +149,7 @@ var CronRow = React.createClass({
         <td id="button"><Button bsStyle={style} onClick={this.toggle_activated_click}>{button_display}</Button></td>
         <td>{job.CronTime}</td>
         <td id="workload">{job.Workload}</td>
+        <td>{this.formatTime(job.Created)}</td>
         <td id="button"><Button bsStyle="danger" onClick={this.delete_click}>{delete_display}</Button></td>
       </tr>
     );
@@ -199,6 +206,7 @@ var JobDetails = React.createClass({
           <td id="buttoncol"></td>
           <td id="croncol">Cron time</td>
           <td>Workload</td>
+          <td>Created</td>
           <td id="buttoncol"></td>
         </tr>
     );


### PR DESCRIPTION
In this PR we
- Scan workload input in the web interface to recognize likely JSON input and determine if it's valid
- Display the job creation date
- Tweak usage messages to be clearer: Explicitly say that direct modification of cronjob isn't currently supported; remove quotes from shadow workload example as quotes are not expected (`"--task job" -> --task job`).

<img width="866" alt="screen shot 2016-01-16 at 8 24 10 am" src="https://cloud.githubusercontent.com/assets/13650281/12373354/843b9662-bc2b-11e5-9bb3-3c1f08a8ee38.png">

<img width="886" alt="screen shot 2016-01-16 at 8 24 31 am" src="https://cloud.githubusercontent.com/assets/13650281/12373362/95c07286-bc2b-11e5-938c-c134b6aa3cf4.png">
