### PR TITLE
feat(db): allow array workloads

### DIFF
--- a/db/mongo_test.go
+++ b/db/mongo_test.go
@@ -33,6 +33,7 @@ func TestParseWorkload(t *testing.T) {
 	}{
 		{Input: "--task", Output: interface{}("--task")},
 		{Input: "{\"foo\":\"bar\"}", Output: bson.M(map[string]interface{}{"foo": "bar"})},
+		{Input: `["array", "of", "items"]`, Output: []interface{}{"array", "of", "items"}},
 	} {
 		assert.Equal(t, test.Output, parseWorkload(test.Input))
 	}

--- a/db/mongodb.go
+++ b/db/mongodb.go
@@ -2,9 +2,10 @@ package db
 
 import (
 	"encoding/json"
+	"time"
+
 	"gopkg.in/mgo.v2"
 	"gopkg.in/mgo.v2/bson"
-	"time"
 )
 
 var (
@@ -46,6 +47,7 @@ func (mc *mongoCronJob) toCronJob() CronJob {
 	case string:
 		workload = t
 	case bson.M:
+	case []interface{}:
 		workloadByte, _ := json.Marshal(t)
 		workload = string(workloadByte)
 	}
@@ -175,8 +177,14 @@ func (db *MongoDB) DeleteJob(jobID string) error {
 
 func parseWorkload(workloadString string) interface{} {
 	var jsonWorkload map[string]interface{}
-	if jsonErr := json.Unmarshal([]byte(workloadString), &jsonWorkload); jsonErr == nil {
+	if err := json.Unmarshal([]byte(workloadString), &jsonWorkload); err == nil {
 		return bson.M(jsonWorkload)
 	}
+
+	var array []interface{}
+	if err := json.Unmarshal([]byte(workloadString), &array); err == nil {
+		return array
+	}
+
 	return workloadString
 }


### PR DESCRIPTION
**Overview:**

Previously, workloads with arrays (as strings) would get them stored as
strings. Arrays in the DB, however, would fail to be converted properly
when converted from Mongo to CronJob, so the data would get dropped.

This allows us to properly save/restore arrays to DB and manipulate them in the UI

<img width="1324" alt="array-in-ui" src="https://user-images.githubusercontent.com/102242/28394343-2fe53302-6ca1-11e7-9eb8-2eef66db198b.png">


<img width="834" alt="array-in-db" src="https://user-images.githubusercontent.com/102242/28394350-437a43da-6ca1-11e7-821e-bc572011ecd5.png">

**Testing:**

Updated unit tests, and manually tested various flows (adding a job, de-activating and re-activating) via UI
