### PR TITLE
mongodb: Properly return json workloads

### DIFF
--- a/db/mongo_test.go
+++ b/db/mongo_test.go
@@ -5,6 +5,7 @@ import (
 	"net/url"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"gopkg.in/mgo.v2"
@@ -37,6 +38,33 @@ func TestParseWorkload(t *testing.T) {
 	} {
 		assert.Equal(t, test.Output, parseWorkload(test.Input))
 	}
+}
+
+func TestToCronJob(t *testing.T) {
+	idHex := "12345678901234567890abcd"
+	id := bson.ObjectIdHex(idHex)
+	v := mongoCronJob{
+		ID:       id,
+		IsActive: true,
+		Function: "echo",
+		Workload: bson.M{"district_id": "abc123"},
+		CronTime: "* * 3 * * *",
+		TimeZone: "America/Los_Angeles",
+		Created:  time.Date(2017, 5, 20, 0, 0, 0, 0, time.UTC),
+		Backend:  "gearman",
+	}
+	actual := v.toCronJob()
+	expected := CronJob{
+		ID:       idHex,
+		IsActive: true,
+		Function: "echo",
+		Workload: `{"district_id":"abc123"}`,
+		CronTime: "* * 3 * * *",
+		TimeZone: "America/Los_Angeles",
+		Created:  time.Date(2017, 5, 20, 0, 0, 0, 0, time.UTC),
+		Backend:  "gearman",
+	}
+	assert.Equal(t, expected, actual)
 }
 
 // Auxilliary wrapper functions

--- a/db/mongodb.go
+++ b/db/mongodb.go
@@ -47,6 +47,8 @@ func (mc *mongoCronJob) toCronJob() CronJob {
 	case string:
 		workload = t
 	case bson.M:
+		workloadByte, _ := json.Marshal(t)
+		workload = string(workloadByte)
 	case []interface{}:
 		workloadByte, _ := json.Marshal(t)
 		workload = string(workloadByte)

--- a/db/mongodb.go
+++ b/db/mongodb.go
@@ -140,10 +140,7 @@ func (db *MongoDB) UpdateJob(cronJob CronJob) error {
 	mongoCron.ID = bson.ObjectId("")
 
 	change := bson.M{"$set": mongoCron}
-	if err := collection.Update(query, change); err != nil {
-		return err
-	}
-	return nil
+	return collection.Update(query, change)
 }
 
 // AddJob parses CronJob input and inserts into DB
@@ -162,11 +159,7 @@ func (db *MongoDB) AddJob(job CronJob) error {
 		Backend:  job.Backend,
 	}
 
-	if insertErr := collection.Insert(&insertJob); insertErr != nil {
-		return insertErr
-	}
-
-	return nil
+	return collection.Insert(&insertJob)
 }
 
 // DeleteJob removes jobID from DB


### PR DESCRIPTION
Golang switches don't fall through (and typeswitches don't allow the `fallthrough` keyword).