### PR TITLE
Support Timezones

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -17,12 +17,6 @@
   revision = "32d9c273155a0506d27cf73dd1246e86a470997e"
 
 [[projects]]
-  branch = "master"
-  name = "github.com/segmentio/go-env"
-  packages = ["."]
-  revision = "ea0600a7760cd15ccca9057be4a87d68e95ee876"
-
-[[projects]]
   name = "github.com/stretchr/testify"
   packages = ["assert"]
   revision = "f5520455607c0233cb6d7b056f71b22c1d265ef1"
@@ -40,10 +34,10 @@
   revision = "bd5ef7bd5415a7ac448318e64f11a24cd21e594b"
 
 [[projects]]
+  branch = "master"
   name = "github.com/xeipuuv/gojsonschema"
   packages = ["."]
-  revision = "f971f3cd73b2899de6923801c147f075263e0c50"
-  version = "v1.1.0"
+  revision = "b537c054d4b486d62f64a76b8d48fdf38a0ea99d"
 
 [[projects]]
   name = "gopkg.in/Clever/kayvee-go.v6"
@@ -68,12 +62,12 @@
 [[projects]]
   name = "gopkg.in/yaml.v2"
   packages = ["."]
-  revision = "51d6538a90f86fe93ac480b35f37b2be17fef232"
-  version = "v2.2.2"
+  revision = "53403b58ad1b561927d19068c655246f2db79d48"
+  version = "v2.2.8"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "0fd762c723bd3d9c39563ab12d9d892f5f5b67571f3b2fdd39a6474ab449fc40"
+  inputs-digest = "a56956e1b62bb76e8c3b16e6926ac665c8720d2d28c393a9c34725a8aa4574f3"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/launch/cron-admin.yml
+++ b/launch/cron-admin.yml
@@ -7,7 +7,7 @@ env:
 - PORT
 resources:
   cpu: 0.1
-  memory: 100
+  max_mem: 0.1
 expose:
 - name: http
   port: 80

--- a/static/js/components/JobDetails.jsx
+++ b/static/js/components/JobDetails.jsx
@@ -31,6 +31,7 @@ var AddForm = React.createClass({
     var crontime = this.refs.crontime.getInputDOMNode().value;
     var workload = this.refs.workload.getInputDOMNode().value.trim();
     var backend = this.refs.backend.getValue();
+    var timezone = this.refs.timezone.getValue();
 
     if (!this.state.json_workload_checked && this.raiseJSONWorkloadWarning(workload)) {
       this.setState({json_workload_checked:true});
@@ -40,7 +41,7 @@ var AddForm = React.createClass({
     $.ajax({
       url: "/jobs",
       type: "POST",
-      data: {Function: this.props.function, CronTime: crontime, Workload: workload, Backend: backend},
+      data: {Function: this.props.function, CronTime: crontime, Workload: workload, Backend: backend, TimeZone: timezone},
       dataType: "json",
       success: function(data) {
         this.props.getJobDetails(this.props.function);
@@ -99,6 +100,11 @@ var AddForm = React.createClass({
         <label>Cron Time</label>
         <Input hasFeedback help={this.state.cron_check.message} bsStyle={this.state.cron_check.status}
           onChange={this.validateCron} ref="crontime" type="text" placeholder={crontime_placeholder} required />
+        <label>Time Zone</label>
+        <Input type="select" ref="timezone">
+          <option value="America/Los_Angeles">America/Los_Angeles</option>
+          <option value="UTC">UTC</option>
+        </Input>
         <label>Workload</label>
         <Input ref="workload" type="textarea" placeholder={workload_placeholder} />
         <label>Backend</label>
@@ -192,7 +198,7 @@ var CronRow = React.createClass({
         <td>
           {job.CronTime}
           <hr></hr>
-          {cronString}
+          {cronString} ({job.TimeZone})
         </td>
         <td id="workload">{workload}</td>
         <td>{this.formatTime(job.Created)}</td>


### PR DESCRIPTION
Support showing and setting timezones, which can help with some easier timing issues. UTC allows us to schedule jobs ignoring daylight savings. PST is easier to think about when exact timing is not as important

Apparently the backend already supported this but the frontend wasn't hooked up. https://github.com/Clever/cron-admin/blob/a3aea7dcfb5260c61d7bd534f11972d75752714e/server/server.go#L163-L166

Before:
![image](https://user-images.githubusercontent.com/13126257/76917365-6ce0dd00-6880-11ea-8735-524d11274374.png)
![image](https://user-images.githubusercontent.com/13126257/76917377-75391800-6880-11ea-9f24-6f09e8fa087b.png)

After:
![image](https://user-images.githubusercontent.com/13126257/76917344-5c306700-6880-11ea-899b-e14a89216d1e.png)
![image](https://user-images.githubusercontent.com/13126257/76917354-62bede80-6880-11ea-94a0-f96034df4f8e.png)
