### PR TITLE
[automated] Upgrade to Go 1.16

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ jobs:
   build:
     working_directory: /go/src/github.com/Clever/cron-admin
     docker:
-    - image: circleci/golang:1.13-stretch
+    - image: circleci/golang:1.16-stretch
     - image: circleci/mongo:3.2.20-jessie-ram
     environment:
       GOPRIVATE: github.com/Clever/*

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ SHELL := /bin/bash
 PKG := github.com/Clever/cron-admin
 PKGS := $(shell go list ./... | grep -v /vendor)
 EXECUTABLE := $(shell basename $(PKG))
-$(eval $(call golang-version-check,1.13))
+$(eval $(call golang-version-check,1.16))
 
 export MONGO_TEST_DB ?= http://127.0.0.1:27017
 


### PR DESCRIPTION
This PR migrates to Go 1.16.

If the build passes, no action is required by you, infra will merge and deploy this. For any questions, reach out to @taylor-sutton (Slack `taylor`) or #oncall-infra.
